### PR TITLE
Update Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## Requirements
 
-- numpy  
-- matplotlib   
-- scipy 
-- PIL  
-- numba  
+- numpy
+- matplotlib
+- scipy
+- PIL
+- numba
 - scikit-image
 - tqdm
 - jupyter
@@ -25,44 +25,56 @@
 
 The sketch above shows the three 'meanderpy' components: channel, cutoff, channel belt. These are implemented as classes; a 'Channel' and a 'Cutoff' are defined by their width, depth, and x,y,z centerline coordinates, and a 'ChannelBelt' is a collection of channels and cutoffs. In addition, the 'ChannelBelt' object also has a 'cl_times' and a 'cutoff_times' attribute that specify the age of the channels and the cutoffs. This age is relative to the start time of the simulation (= the first channel, age = 0.0).
 
-The initial Channel object can be created using the 'generate_initial_channel' function. This creates a straight line, with some noise added. However, a Channel can be created (and then used as the first channel in a ChannelBelt) using any set of x,y,z,W,D variables.
+To run the below cells, you must first import the library:
 
 ```python
-ch = mp.generate_initial_channel(W,D,Sl,deltas,pad,n_bends) # initialize channel
-chb = mp.ChannelBelt(channels=[ch],cutoffs=[],cl_times=[0.0],cutoff_times=[]) # create channel belt object
+import meanderpy as mp
+import numpy as np
 ```
 
 A reasonable set of input parameters are as follows:
 
 ```python
+nit = 1500                   # number of iterations
 W = 200.0                    # channel width (m)
-D = 16.0                     # channel depth (m)
+D = 6.0                      # channel depth (m)
+depths = D * np.ones((nit,))  # channel depths for different iterations
 pad = 100                    # padding (number of nodepoints along centerline)
 deltas = 50.0                # sampling distance along centerline
-nit = 1500                   # number of iterations
-Cf = 0.03                    # dimensionless Chezy friction factor
-crdist = W                   # threshold distance at which cutoffs occur
+Cfs = 0.011 * np.ones((nit,)) # dimensionless Chezy friction factor
+crdist = 2 * W               # threshold distance at which cutoffs occur
 kl = 60.0/(365*24*60*60.0)   # migration rate constant (m/s)
-kv =  3*10*5.0E-13           # vertical slope-dependent erosion rate constant (m/s)
-dt = 0.1*(365*24*60*60.0)    # time step (s)
+kv =  1.0e-12               # vertical slope-dependent erosion rate constant (m/s)
+dt = 2*0.05*365*24*60*60.0     # time step (s)
 dens = 1000                  # density of water (kg/m3)
 saved_ts = 20                # which time steps will be saved
 n_bends = 30                 # approximate number of bends you want to model
-Sl = 0.0                     # initial slope (setting this to non-zero results in instabilities in long runs)
+Sl = 0.0                     # initial slope (matters more for submarine channels than rivers)
+t1 = 500                    # time step when incision starts
+t2 = 700                    # time step when lateral migration starts
+t3 = 1200                    # time step when aggradation starts
+aggr_factor = 2e-9         # aggradation factor (m/s, about 0.18 m/year, it kicks in after t3)
+```
+
+The initial Channel object can be created using the 'generate_initial_channel' function. This creates a straight line, with some noise added. However, a Channel can be created (and then used as the first channel in a ChannelBelt) using any set of x,y,z,W,D variables.
+
+```python
+ch = mp.generate_initial_channel(W, depths[0], Sl, deltas, pad, n_bends) # initialize channel
+chb = mp.ChannelBelt(channels=[ch], cutoffs=[], cl_times=[0.0], cutoff_times=[]) # create channel belt object
 ```
 
 The core functionality of 'meanderpy' is built into the 'migrate' method of the 'ChannelBelt' class. This is the function that computes migration rates and moves the channel centerline to its new position. The last Channel of a ChannelBelt can be further migrated through applying the 'migrate' method to the ChannelBelt instance.
 
 ```python
-chb.migrate(nit,saved_ts,deltas,pad,crdist,Cf,kl,kv,dt,dens) # channel migration
+chb.migrate(nit,saved_ts,deltas,pad,crdist,depths,Cfs,kl,kv,dt,dens,t1,t2,t3,aggr_factor) # channel migration
 ```
 
-ChannelBelt objects can be visualized using the 'plot' method. This creates a map of all the channels and cutoffs in the channel belt; there are two styles of plotting: a 'stratigraphic' view and a 'morphologic' view (see below). The morphologic view tries to account for the fact that older point bars and oxbow lakes tend to be gradually covered with vegetation. 
+ChannelBelt objects can be visualized using the 'plot' method. This creates a map of all the channels and cutoffs in the channel belt; there are two styles of plotting: a 'stratigraphic' view and a 'morphologic' view (see below). The morphologic view tries to account for the fact that older point bars and oxbow lakes tend to be gradually covered with vegetation.
 
 ```python
 # migrate an additional 1000 iterations and plot results
-chb.migrate(1000,saved_ts,deltas,pad,crdist,Cf,kl,kv,dt,dens)
-fig = chb.plot('strat',20,60)
+chb.migrate(1000,saved_ts,deltas,pad,crdist,depths,Cfs,kl,kv,dt,dens,t1,t2,t3,aggr_factor)
+fig = chb.plot('strat', 20, 60, chb.cl_times[-1], len(chb.channels)) # plotting
 ```
 
 <img src="https://github.com/zsylvester/meanderpy/blob/master/meanderpy_strat_vs_morph.png" width="1000">


### PR DESCRIPTION
The example code in the readme didn't run as presented - not sure if this is because the package changed or what. I grabbed code from the functional example notebook and put it into the readme, and reorganized the presentation of code in the readme so it can be executed if entered into the console in order.

Merge if you'd like.