### PR TITLE
Replace np.NaN with np.nan for consistency

### DIFF
--- a/meanderpy/meanderpy.py
+++ b/meanderpy/meanderpy.py
@@ -561,7 +561,7 @@ def build_3d_model(chb, model_type, h_mud, h, w, dx, delta_s, dt, starttime, end
     topoinit = z1[0] - ((z1[0] - z1[-1]) / (xmax - xmin)) * xv * dx # initial (sloped) topography
     topo[:,:,0] = topoinit.copy()
     surf = topoinit.copy()
-    facies[0] = np.NaN
+    facies[0] = np.nan
     # generate surfaces:
     channels3D = []
     for i in trange(n_steps):
@@ -580,7 +580,7 @@ def build_3d_model(chb, model_type, h_mud, h, w, dx, delta_s, dt, starttime, end
         topo[:,:,3*i] = surf # erosional surface
         dists[:,:,i] = cl_dist # distance map
         zmaps[:,:,i] = z_map # map of closest channel elevation
-        facies[3*i] = np.NaN # array for facies code
+        facies[3*i] = np.nan # array for facies code
 
         if model_type == 'fluvial':
             z_map = gaussian_filter(z_map, sigma=50) # smooth z_map to avoid artefacts in levees
@@ -982,11 +982,11 @@ def find_cutoffs(x,y,crdist,deltas):
     diag_blank_width = int((crdist+20*deltas)/deltas)
     # distance matrix for centerline points:
     dist = distance.cdist(np.array([x,y]).T,np.array([x,y]).T)
-    dist[dist>crdist] = np.NaN # set all values that are larger than the cutoff threshold to NaN
+    dist[dist>crdist] = np.nan # set all values that are larger than the cutoff threshold to NaN
     # set matrix to NaN along the diagonal zone:
     for k in range(-diag_blank_width,diag_blank_width+1):
         rows, cols = kth_diag_indices(dist,k)
-        dist[rows,cols] = np.NaN
+        dist[rows,cols] = np.nan
     i1, i2 = np.where(~np.isnan(dist))
     ind1 = i1[np.where(i1<i2)[0]] # get rid of unnecessary indices
     ind2 = i2[np.where(i1<i2)[0]] # get rid of unnecessary indices


### PR DESCRIPTION
AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[7], line 1
----> 1 chb.migrate(nit,saved_ts,deltas,pad,crdist,depths,Cfs,kl,kv,dt,dens) #,t1,t2,t3,aggr_factor) # channel migration
      2 fig = chb.plot('strat', 20, 60, chb.cl_times[-1], len(chb.channels)) # plotting

File /mnt/e/meanderpy/meanderpy/meanderpy.py:260, in ChannelBelt.migrate(self, nit, saved_ts, deltas, pad, crdist, depths, Cfs, kl, kv, dt, dens, autoaggradation, Scr, t1, t2, t3, aggr_factor)
    258 x, y = migrate_one_step(x,y,z,W,kl,dt,k,Cf,D,pad,pad1)
    259 # x, y = migrate_one_step_w_bias(x,y,z,W,kl,dt,k,Cf,D,pad,pad1)
--> 260 x,y,z,xc,yc,zc = cut_off_cutoffs(x,y,z,s,crdist,deltas) # find and execute cutoffs
    261 x,y,z,dx,dy,dz,ds,s = resample_centerline(x,y,z,deltas) # resample centerline
    262 z = savgol_filter(z, 21, 2) # filter z-values - needed for autoaggradation

File /mnt/e/meanderpy/meanderpy/meanderpy.py:1032, in cut_off_cutoffs(x, y, z, s, crdist, deltas)
   1030 yc = []
   1031 zc = []
-> 1032 ind1, ind2 = find_cutoffs(x,y,crdist,deltas) # initial check for cutoffs
   1033 while len(ind1)>0:
   1034     xc.append(x[ind1[0]:ind2[0]+1]) # x coordinates of cutoff

File /mnt/e/meanderpy/meanderpy/meanderpy.py:985, in find_cutoffs(x, y, crdist, deltas)
    983 # distance matrix for centerline points:
    984 dist = distance.cdist(np.array([x,y]).T,np.array([x,y]).T)
--> 985 dist[dist>crdist] = np.NaN # set all values that are larger than the cutoff threshold to NaN
    986 # set matrix to NaN along the diagonal zone:
    987 for k in range(-diag_blank_width,diag_blank_width+1):

File ~/miniconda3/envs/torchy/lib/python3.12/site-packages/numpy/__init__.py:781, in __getattr__(attr)
    778     raise AttributeError(__former_attrs__[attr], name=None)
    780 if attr in __expired_attributes__:
--> 781     raise AttributeError(
    782         f"`np.{attr}` was removed in the NumPy 2.0 release. "
    783         f"{__expired_attributes__[attr]}",
    784         name=None
    785     )
    787 if attr == "chararray":
    788     warnings.warn(
    789         "`np.chararray` is deprecated and will be removed from "
    790         "the main namespace in the future. Use an array with a string "
    791         "or bytes dtype instead.", DeprecationWarning, stacklevel=2)

AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.